### PR TITLE
Older glibc based build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,16 +33,19 @@ jobs:
     needs: test_routine
     name: "Build (Linux)"
     runs-on: ubuntu-latest
+    container:
+      image: fydeinc/pyinstaller@sha256:bbad26fc29dc6852033901f25f8f52ec19bdf499e4915309cd2a489fff1c6379
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build binary
+        env:
+            PLATFORMS: "linux"
+            SRCDIR: ${{ github.workspace }}
         run: |
-             pip3 install -r requirements.txt
-             pip3 install pyinstaller==4.8
-             pyinstaller --paths=src --name=meterian-pr --onefile src/Main.py
-             ./dist/meterian-pr --version
+             dumb-init -- /entrypoint.sh --paths=src --name=meterian-pr --hidden-import _cffi_backend src/Main.py
+             ./dist/linux/meterian-pr --version
 
       - name: Package binary
         run: ./scripts/archive_tool.sh meterian-pr_linux.tar.gz
@@ -59,20 +62,21 @@ jobs:
     name: "Build (Alpine Linux)"
     runs-on: ubuntu-latest
     container:
-      image: meterian/cli:latest
+      image: fydeinc/pyinstaller@sha256:bbad26fc29dc6852033901f25f8f52ec19bdf499e4915309cd2a489fff1c6379
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build binary
+        env:
+            PLATFORMS: "alpine,linux"
+            SRCDIR: ${{ github.workspace }}
         run: |
-             pip3 install -r requirements.txt
-             pip3 install pyinstaller==4.8
-             pyinstaller --paths=src --name=meterian-pr --onefile src/Main.py --hidden-import _cffi_backend
-             ./dist/meterian-pr --version
+             /switch_to_alpine.sh --paths=src --name=meterian-pr --hidden-import _cffi_backend src/Main.py
+             ./dist/alpine/meterian-pr --version
 
       - name: Package binary
-        run: ./scripts/archive_tool.sh meterian-pr_alpine-linux.tar.gz
+        run: sh scripts/archive_tool.sh meterian-pr_alpine-linux.tar.gz
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests~=2.22.0
+requests~=2.25.0
 PyGitHub==1.55
 python-gitlab==3.9.0

--- a/scripts/archive_tool.sh
+++ b/scripts/archive_tool.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 mkdir -p bin
-cp README.md LICENSE dist/meterian-pr bin/
+cp README.md LICENSE dist/*/meterian-pr bin/
 tar -zcf "$1" bin

--- a/src/Main.py
+++ b/src/Main.py
@@ -35,7 +35,7 @@ ACTIONS = [ "PR", "ISSUE" ]
 
 WORK_DIR = None
 
-VERSION = "1.1.7"
+VERSION = "1.1.8"
 
 log = logging.getLogger("Main")
 

--- a/src/vcs/IssueSubmitter.py
+++ b/src/vcs/IssueSubmitter.py
@@ -49,6 +49,6 @@ class IssueSubmitter:
         label = self.repo.get_issue_label()
         label_available = self.repo.create_label(label.name, label.description, label.color, label.text_color)
         if label_available:
-            return [self.repo.get_pr_label().name]
+            return [self.repo.get_issue_label().name]
         else:
             return []


### PR DESCRIPTION
- Changed workflow to build package on machine with a [lower version of glibc](https://github.com/pyinstaller/pyinstaller/discussions/5669) to increase portability.
- Applied minor fix to the IssueSubmitter