### PR TITLE
Fix for issues_enabled deprecated attibute

### DIFF
--- a/src/Main.py
+++ b/src/Main.py
@@ -42,7 +42,7 @@ WORK_DIR = None
 
 PR_REPORT_FILENAME_PREFIX = ".pr_report_"
 
-VERSION = "1.1.22"
+VERSION = "1.1.23"
 
 METERIAN_ENV = os.environ["METERIAN_ENV"] if "METERIAN_ENV" in os.environ else "www"
 METERIAN_DOMAIN = os.environ["METERIAN_DOMAIN"] if "METERIAN_DOMAIN" in os.environ else "meterian.io"

--- a/src/vcs/gitlab/GitlabProject.py
+++ b/src/vcs/gitlab/GitlabProject.py
@@ -43,7 +43,7 @@ class GitlabProject(RepositoryInterface):
         self.namespace = self.__getOrDefault(self.pyGitlabProject.namespace, 'path', None)
         self.name = self.pyGitlabProject.path
         self.default_branch = self.pyGitlabProject.default_branch
-        self.issues_enabled = self.pyGitlabProject.issues_enabled
+        self.issues_enabled = self.__is_issues_enabled()
 
         # despite having access to a project you may still not access to ownership info
         if hasattr(pyGitlabProject, "owner"):
@@ -241,6 +241,10 @@ class GitlabProject(RepositoryInterface):
             self.__log.debug("Unable to create label %s for project %s", label_data.name, self.get_full_name(), exc_info=1)
 
         return label
+
+    def __is_issues_enabled(self):
+        count = len(self.pyGitlabProject.issues.gitlab.projects.list(with_issues_enabled=True, id_after=self.pyGitlabProject.id-1, id_before=self.pyGitlabProject.id+1))
+        return count > 0
 
     def __str__(self):
         return "GitlabProject [ namespace=" + str(self.namespace) + ", name=" + str(self.name) + ", default_branch=" + str(self.default_branch) + ", owner=" + str(self.owner) + ", issues_enabled=" + str(self.issues_enabled) + " ]"

--- a/tests/vcs/gitlab/GitlabTest.py
+++ b/tests/vcs/gitlab/GitlabTest.py
@@ -16,10 +16,14 @@ class GitlabTest(unittest.TestCase):
     def setUp(self) -> None:
         self.pyGitlab = Mock(spec=PyGitlab)
         self.gitlab = Gitlab(self.pyGitlab)
-        self.projects = Mock(spec=ProjectManager)
+
+        self.projects = MagicMock(spec=ProjectManager)
         self.pyGitlab.projects = self.projects
+
         self.issues = Mock(spec=IssueManager)
         self.pyGitlab.issues = self.issues
+
+        self.issues.gitlab = self.pyGitlab
 
     def test_should_get_none_when_repository_is_not_found(self):
         self.pyGitlab.projects.get = MagicMock(side_effect=GitlabHttpError("404 Project Not Found", 404, None))
@@ -41,7 +45,7 @@ class GitlabTest(unittest.TestCase):
 
     def test_should_fetch_issues_by_title(self):
         self.issues.list = MagicMock(return_value=[self.__create_open_issue("Sample issue 12345")])
-        project = self.__create_project("MyOrg/MyRepo")
+        project = self.__create_issueless_project("MyOrg/MyRepo")
         project.issues = self.issues
         self.pyGitlab.projects.get = MagicMock(return_value=project)
 
@@ -73,6 +77,9 @@ class GitlabTest(unittest.TestCase):
 
     def __create_project(self, name: str):
         return GitlabTestFunctions.create_project(name)
+
+    def __create_issueless_project(self, name: str):
+        return GitlabTestFunctions.create_issueless_project(name)
 
 
 if __name__ == "__main__":

--- a/tests/vcs/gitlab/GitlabTestFunctions.py
+++ b/tests/vcs/gitlab/GitlabTestFunctions.py
@@ -1,13 +1,37 @@
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 from gitlab.v4.objects.projects import Project
+from gitlab.v4.objects.issues import IssueManager
+from gitlab.v4.objects.issues import Issue
+from gitlab.v4.objects.projects import ProjectManager
+from gitlab import Gitlab as PyGitlab
 
 class GitlabTestFunctions:
-    def create_project(OrgAndRepo): 
+    def create_issueless_project(OrgAndRepo): 
         tokens = OrgAndRepo.rsplit('/', 1)
         project = Mock(spec=Project)
+        project.id = 1111
         project.namespace = { 'path': tokens[0] }
         project.path = tokens[1]
         project.default_branch = "master"
         project.owner = {}
-        project.issues_enabled = True
+        return project
+
+    def create_project(OrgAndRepo): 
+        tokens = OrgAndRepo.rsplit('/', 1)
+        project = Mock(spec=Project)
+        project.id = 1111
+        project.namespace = { 'path': tokens[0] }
+        project.path = tokens[1]
+        project.default_branch = "master"
+        project.owner = {}
+        # project.issues_enabled = True DEPRECATED
+
+        pyGitlab = Mock(spec=PyGitlab)
+        projects = MagicMock(spec=ProjectManager)
+        issues = Mock(spec=IssueManager)
+
+        pyGitlab.projects = projects
+        issues.gitlab = pyGitlab
+        project.issues = issues
+
         return project


### PR DESCRIPTION
The attribute `issues_enabled` of a Gitlab Project is no longer supported so changes were made in this PR to restore the functionality in the meterian-pr tool.